### PR TITLE
Calculate real offset of instruction

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ fn main() {
     } else {
         for (idx, insn) in rbpf::disassembler::to_insn_vec(&prog).iter().enumerate() {
             if number {
-                print!("{:>6}  ", idx);
+                print!("{:>6}  ", idx+1);
             }
             println!("{}", insn.desc.replace(" ", "\t"));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ fn main() {
 //
 // Jumps are relative from the current instruction pointer
 fn is_jmp(insn: &rbpf::disassembler::HLInsn) -> bool {
-    (insn.opc & 0xf) == rbpf::ebpf::BPF_JMP &&
+    (insn.opc & 0x07) == rbpf::ebpf::BPF_JMP &&
         (insn.opc != rbpf::ebpf::CALL) &&
         (insn.opc != rbpf::ebpf::TAIL_CALL) &&
         (insn.opc != rbpf::ebpf::EXIT)


### PR DESCRIPTION
One instruction, `LD_DW_IMM`, actually spreads across two instructions.
If we want to display instruction offsets this needs to be taken into account.

We also display the target for jumps now.