### PR TITLE
Fix off-by-one when calculating jump targets

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,10 @@ fn main() {
             }
             print!("{}", insn.desc.replace(" ", "\t"));
 
+            // PC is incremented after the instruction if fetched
+            // but before it's side effects are applied.
+            idx += 1;
+
             if is_jmp(&insn) {
                 print!("\t(jump to {})", idx + insn.off as isize);
             }
@@ -166,7 +170,6 @@ fn main() {
             }
 
             println!();
-            idx += 1;
         }
     }
 }


### PR DESCRIPTION
If we look at how [__bpf_prog_run()](https://elixir.bootlin.com/linux/v5.2.4/source/kernel/bpf/core.c#L1481) kernel function handles JE instruction, for example, we'll see that it increments the PC twice:

* first by the offset number encoded in the instruction
* second by one when issuing CONT macro

This is similar to what's being done in [uBPF](https://github.com/iovisor/ubpf/blob/9d10569738730a7357c706bf1d62c53ef5d329ad/vm/ubpf_vm.c#L147) or [rbpf's JIT](https://github.com/qmonnet/rbpf/blob/ceb7fa67946a7a6e9cff5a4e03ae721a1ecf10b6/src/jit.rs#L523).